### PR TITLE
Adding static names to the routes to avoid typos

### DIFF
--- a/lib/ui/auth/login.dart
+++ b/lib/ui/auth/login.dart
@@ -1,9 +1,12 @@
+import 'package:dear_diary/ui/auth/sign_up.dart';
 import 'package:dear_diary/utils/input_validator.dart';
 import 'package:dear_diary/view_model/base.dart';
 import 'package:dear_diary/view_model/user.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
+import '../home.dart';
 
 class Login extends StatefulWidget {
   static const routeName = 'login';
@@ -23,7 +26,7 @@ class _LoginState extends State<Login> {
   }
 
   _handleSignUpTap() {
-    Navigator.of(context).pushNamed('signup');
+    Navigator.of(context).pushNamed(SignUp.routeName);
   }
 
   @override
@@ -232,7 +235,7 @@ class _LoginState extends State<Login> {
         .login(_formData);
     if (response) {
       Navigator.of(context)
-          .pushNamedAndRemoveUntil('home', (Route<dynamic> route) => false);
+          .pushNamedAndRemoveUntil(Home.routeName, (Route<dynamic> route) => false);
     }
   }
 

--- a/lib/ui/auth/sign_up.dart
+++ b/lib/ui/auth/sign_up.dart
@@ -5,6 +5,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'login.dart';
+
 class SignUp extends StatefulWidget {
   static const routeName = 'signup';
 
@@ -24,7 +26,7 @@ class _SignUpState extends State<SignUp> {
   }
 
   _handleLoginTap() {
-    Navigator.of(context).pushNamed('login');
+    Navigator.of(context).pushNamed(Login.routeName);
   }
 
   @override
@@ -252,7 +254,7 @@ class _SignUpState extends State<SignUp> {
     final response = await Provider.of<UserViewModel>(context, listen: false)
         .create(_formData);
     if (response) {
-      Navigator.of(context).popAndPushNamed('login');
+      Navigator.of(context).popAndPushNamed(Login.routeName);
     }
   }
 

--- a/lib/ui/entries/add_entry.dart
+++ b/lib/ui/entries/add_entry.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../home.dart';
+
 class AddEntry extends StatefulWidget {
   static const routeName = 'add-entry';
 
@@ -133,7 +135,7 @@ class _AddEntryState extends State<AddEntry> {
     final response = await Provider.of<EntryViewModel>(context, listen: false)
         .create(_formData);
     if (response) {
-      Navigator.of(context).pushNamed('home');
+      Navigator.of(context).pushNamed(Home.routeName);
     }
   }
 }

--- a/lib/ui/entries/edit_entry.dart
+++ b/lib/ui/entries/edit_entry.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../home.dart';
+
 class EditEntry extends StatefulWidget {
   static const routeName = 'edit-entry';
 
@@ -138,7 +140,7 @@ class _EditEntryState extends State<EditEntry> {
     final response = await Provider.of<EntryViewModel>(context, listen: false)
         .update(_formData);
     if (response) {
-      Navigator.of(context).popAndPushNamed('home');
+      Navigator.of(context).popAndPushNamed(Home.routeName);
     }
   }
 }

--- a/lib/ui/entries/list_entries.dart
+++ b/lib/ui/entries/list_entries.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:dear_diary/models/entry.dart';
+import 'package:dear_diary/ui/entries/view_entry.dart';
 import 'package:dear_diary/view_model/base.dart';
 import 'package:dear_diary/view_model/entry.dart';
 import 'package:flutter/material.dart';
@@ -38,7 +39,7 @@ class _ListEntriesState extends State<ListEntries> {
 
               return GestureDetector(
                 onTap: () => Navigator.of(context)
-                    .pushNamed('view-entry', arguments: entry),
+                    .pushNamed(ViewEntry.routeName, arguments: entry),
                 child: Container(
                   margin: EdgeInsets.only(bottom: 15.0, top: 15.0),
                   child: Row(

--- a/lib/ui/entries/view_entry.dart
+++ b/lib/ui/entries/view_entry.dart
@@ -1,9 +1,12 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:dear_diary/models/entry.dart';
 import 'package:dear_diary/ui/common/diary_confirm_dialog.dart';
+import 'package:dear_diary/ui/entries/edit_entry.dart';
 import 'package:dear_diary/view_model/entry.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
+import '../home.dart';
 
 class ViewEntry extends StatefulWidget {
   static const routeName = 'view-entry';
@@ -179,7 +182,7 @@ class _ViewEntryState extends State<ViewEntry>
                           child: InkResponse(
                             onTap: () {
                               Navigator.of(context)
-                                  .pushNamed('edit-entry', arguments: entry);
+                                  .pushNamed(EditEntry.routeName, arguments: entry);
                             },
                             child: Container(
                               padding: EdgeInsets.all(10),
@@ -272,7 +275,7 @@ class _ViewEntryState extends State<ViewEntry>
     final response = await Provider.of<EntryViewModel>(context, listen: false)
         .delete(entryId);
     if (response) {
-      Navigator.of(context).popAndPushNamed('home');
+      Navigator.of(context).popAndPushNamed(Home.routeName);
     }
   }
 

--- a/lib/ui/intro/intro.dart
+++ b/lib/ui/intro/intro.dart
@@ -1,5 +1,7 @@
+import 'package:dear_diary/ui/auth/sign_up.dart';
 import 'package:flutter/material.dart';
 
+import '../auth/login.dart';
 import 'intro_slide.dart';
 
 class Intro extends StatelessWidget {
@@ -31,7 +33,7 @@ class Intro extends StatelessWidget {
                     shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(30.0)),
                     onPressed: () {
-                      Navigator.of(context).pushNamed('signup');
+                      Navigator.of(context).pushNamed(SignUp.routeName);
                     },
                     child: Text(
                       'Create Account',
@@ -49,7 +51,7 @@ class Intro extends StatelessWidget {
                         side: BorderSide(color: Color(0xFFC4C4C4), width: 1.2),
                         borderRadius: BorderRadius.circular(30.0)),
                     onPressed: () {
-                      Navigator.of(context).pushNamed('login');
+                      Navigator.of(context).pushNamed(Login.routeName);
                     },
                     child: Text(
                       'Login',

--- a/lib/ui/profile/profile.dart
+++ b/lib/ui/profile/profile.dart
@@ -4,6 +4,8 @@ import 'package:dear_diary/view_model/user.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../intro/intro.dart';
+
 class Profile extends StatefulWidget {
   @override
   _ProfileState createState() => _ProfileState();
@@ -209,7 +211,7 @@ class LogoutButton extends StatelessWidget {
       onPressed: () async {
         await AuthHelper.removeUserToken();
         Navigator.of(context)
-            .pushNamedAndRemoveUntil('intro', (Route<dynamic> route) => false);
+            .pushNamedAndRemoveUntil(Intro.routeName, (Route<dynamic> route) => false);
       },
       child: Text(
         'LOG OUT',


### PR DESCRIPTION
It's great to have static names to the routes. But you were not using when doing navigation. I guess this pr is an improve, since this can prevent typos