### PR TITLE
Fix android build error

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,6 +48,10 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    packagingOptions {
+        pickFirst 'META-INF/proguard/androidx-annotations.pro'
+    }
 }
 
 flutter {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cached_network_image: ^1.1.3
+  cached_network_image: ^2.0.0-rc
   cupertino_icons: ^0.1.2
   dio: ^3.0.6
   email_validator: ^1.0.0
@@ -31,6 +31,7 @@ dependencies:
   provider: ^3.0.0+1
   shared_preferences: ^0.5.3+4
   intl: ^0.16.0
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Project was not building, fixed by:
- changing cached_network_image from ^1.1.3 to ^2.0.0-rc in pubspec.yaml
- adding `packagingOptions { pickFirst 'META-INF/proguard/androidx-annotations.pro' }` to ./android/app/build.gradle