### PR TITLE
Fix typos and add basic validator tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ There is still room for improvement
 - Show some :heart: and :star: the repo to encourage more useful OS projects
 
 ## Contributing
-The sole purpose of this project is to facilate learning, PRs and all forms of contribution are very much welcome! 
+The sole purpose of this project is to facilitate learning, PRs and all forms of contribution are very much welcome!
 Consider running [REST API project](https://github.com/Alameen688/MyDiary/tree/develop) locally during development. 
 
 ## Code of Conduct

--- a/lib/ui/entries/list_entries.dart
+++ b/lib/ui/entries/list_entries.dart
@@ -162,7 +162,7 @@ class EntryImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Hero(
-      tag: imageProvider,
+      tag: heroTag,
       child: Container(
         width: 200,
         height: 250,

--- a/lib/ui/entries/view_entry.dart
+++ b/lib/ui/entries/view_entry.dart
@@ -299,7 +299,7 @@ class EntryHeaderImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Hero(
-      tag: imageProvider,
+      tag: heroTag,
       child: Container(
         height: 340.0,
         width: MediaQuery.of(context).size.width,

--- a/lib/view_model/entry.dart
+++ b/lib/view_model/entry.dart
@@ -59,7 +59,7 @@ class EntryViewModel extends BaseViewModel {
       response = await _entryService.updateEntry(formData);
       setStatus(ViewStatus.Ready);
       await _dialogService.showAlertDialog(
-          'Well recieved 😎! Thanks for the update',
+          'Well received 😎! Thanks for the update',
           barrierDismissible: false);
     } on DioError catch (e) {
       final data = e.response?.data ?? {};

--- a/test/input_validator_test.dart
+++ b/test/input_validator_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dear_diary/utils/input_validator.dart';
+
+void main() {
+  group('InputValidator.email', () {
+    test('returns error when email is empty', () {
+      expect(InputValidator.email(''), 'Please provide your email address!');
+    });
+
+    test('returns error when email is invalid', () {
+      expect(InputValidator.email('invalid'), 'Please enter a valid email!');
+    });
+
+    test('returns null for valid email', () {
+      expect(InputValidator.email('test@example.com'), isNull);
+    });
+  });
+
+  group('InputValidator.password', () {
+    test('returns error when password is empty', () {
+      expect(InputValidator.password(''), 'Please provide your password!');
+    });
+
+    test('returns error when password is too short', () {
+      expect(InputValidator.password('ab'), 'Password must be between 3 - 100 characters!');
+    });
+
+    test('returns error when password has special characters', () {
+      expect(InputValidator.password('abc!'), 'Sorry, special characters are not allowed!');
+    });
+
+    test('returns null for valid password', () {
+      expect(InputValidator.password('abc123'), isNull);
+    });
+  });
+
+  group('InputValidator.name', () {
+    test('returns error when name is empty', () {
+      expect(InputValidator.name(''), 'Please provide your name!');
+    });
+
+    test('returns null for non-empty name', () {
+      expect(InputValidator.name('Alice'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- correct "received" typo in entry dialog
- fix hero tag usage in entry image widgets
- clarify README language about facilitating learning
- add basic unit tests for the InputValidator

## Testing
- `flutter test` *(fails: command not found)*

------
<!-- https://chatgpt.com/codex/tasks/task_e_683f78bdfc34832c84957e281ddfcbc5 -->